### PR TITLE
Changing Rackspace::Cloud::Server to OS::Nova:Server 

### DIFF
--- a/basicweb.yaml
+++ b/basicweb.yaml
@@ -115,7 +115,7 @@ resources:
     properties:
       count: { get_param: server_count }
       resource_def:
-        type: Rackspace::Cloud::Server
+        type: OS::Nova::Server
         properties:
           name: srv%index%
           image: { get_param: image }


### PR DESCRIPTION
As per update from Product International (depreciation of Rackspace::Cloud::Server)
